### PR TITLE
Add templates page and fix use case detail metadata

### DIFF
--- a/src/pages/TemplatesPage.tsx
+++ b/src/pages/TemplatesPage.tsx
@@ -1,0 +1,97 @@
+import React from 'react';
+import { Helmet } from 'react-helmet-async';
+import { Sparkles, Layers3, Wand2 } from 'lucide-react';
+import Navbar from '@/components/Navbar';
+import DarkFooter from '@/components/DarkFooter';
+import Button from '@/components/ui/Button';
+import TemplatesGallery from '@/sections/TemplatesGallery';
+
+const highlights = [
+  {
+    icon: <Sparkles className="w-5 h-5 text-cyan-400" />,
+    title: 'Ready on day one',
+    copy: 'Launch proven automations without writing prompts from scratch.',
+  },
+  {
+    icon: <Layers3 className="w-5 h-5 text-cyan-400" />,
+    title: 'Built for your stack',
+    copy: 'Each template documents inputs, data connections, and handoff steps.',
+  },
+  {
+    icon: <Wand2 className="w-5 h-5 text-cyan-400" />,
+    title: 'Fully customizable',
+    copy: 'Clone, remix, and adapt flows as your team experiments.',
+  },
+];
+
+export default function TemplatesPage() {
+  return (
+    <main className="page-animate min-h-screen bg-gray-950 text-white">
+      <Helmet>
+        <title>Templates — ArtikAi</title>
+        <meta
+          name="description"
+          content="Browse automation templates for support, sales, marketing, and operations teams."
+        />
+      </Helmet>
+
+      <Navbar variant="dark" />
+
+      <header className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 pt-16 pb-10">
+        <div className="grid gap-8 lg:grid-cols-[minmax(0,1fr)_360px] items-start">
+          <div>
+            <h1 className="text-3xl md:text-5xl font-extrabold tracking-tight">Automation templates</h1>
+            <p className="mt-4 text-lg text-white/70 max-w-2xl">
+              Skip the blank canvas. Start with curated workflows for chat, voice, and internal tools that already follow
+              best practices across industries.
+            </p>
+            <div className="mt-6 flex flex-wrap gap-3">
+              <Button href="/book">Talk to our team</Button>
+              <Button variant="ghost" href="/docs">View implementation guide</Button>
+            </div>
+          </div>
+          <div className="rounded-2xl border border-white/10 bg-white/5 p-6 backdrop-blur">
+            <h2 className="text-base font-semibold text-white/80">Included with every template</h2>
+            <ul className="mt-4 space-y-3 text-sm text-white/70">
+              <li>• Structured hand-off instructions for humans</li>
+              <li>• Example CRM and calendar mappings</li>
+              <li>• Guardrails and evaluation checklist</li>
+            </ul>
+          </div>
+        </div>
+      </header>
+
+      <section className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 pb-12 grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+        {highlights.map((item) => (
+          <div key={item.title} className="rounded-2xl border border-white/10 bg-gray-900/60 p-6">
+            <div className="flex items-center gap-2 text-sm text-white/70">
+              {item.icon}
+              <span>{item.title}</span>
+            </div>
+            <p className="mt-3 text-white/80">{item.copy}</p>
+          </div>
+        ))}
+      </section>
+
+      <TemplatesGallery />
+
+      <section className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8 pb-20">
+        <div className="rounded-2xl bg-gradient-to-r from-cyan-500/10 to-blue-600/10 border border-cyan-500/10 p-8">
+          <div className="grid gap-6 md:grid-cols-2 md:items-center">
+            <div>
+              <h2 className="text-2xl md:text-3xl font-bold">Need something bespoke?</h2>
+              <p className="mt-2 text-white/70">
+                Our team adapts templates for regulated industries, multilingual deployments, and complex back office flows.
+              </p>
+            </div>
+            <div className="flex md:justify-end">
+              <Button href="/services">Explore professional services</Button>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <DarkFooter />
+    </main>
+  );
+}

--- a/src/pages/UseCaseDetailPage.tsx
+++ b/src/pages/UseCaseDetailPage.tsx
@@ -33,7 +33,7 @@ const useCaseContent: Record<UseCaseSlug, UseCaseContent> = {
     heroMetrics: [
       { label: "Auto-resolved tickets", value: "68%" },
       { label: "Post-automation CSAT", value: "4.7 / 5" },
-      { label: "Channels", value: "Chat · Email · SMS" },
+      { label: "Channels", value: "Chat ï¿½ Email ï¿½ SMS" },
     ],
     summaryBullets: [
       "Train on help-center docs, SOPs, and transcripts in minutes with guardrails you control.",
@@ -239,7 +239,7 @@ const useCaseContent: Record<UseCaseSlug, UseCaseContent> = {
   apps: {
     name: "AI App Creation",
     heroLabel: "Internal tooling",
-    heroHeadline: "Prototype internal apps and portals 3× faster",
+    heroHeadline: "Prototype internal apps and portals 3ï¿½ faster",
     heroDescription:
       "Combine drag-and-drop UI blocks with AI-generated logic so teams can ship polished workflows without waiting on engineering queues.",
     heroMetrics: [
@@ -375,7 +375,7 @@ export default function UseCaseDetailPage() {
   return (
     <main className="page-animate min-h-screen bg-[#050B1A] text-white">
       <Helmet>
-        <title>{${config.name} — Use Cases | ArtikAi}</title>
+        <title>{`${config.name} â€” Use Cases | ArtikAi`}</title>
         <meta name="description" content={config.seoDescription} />
       </Helmet>
       <Navbar variant="dark" />
@@ -497,7 +497,7 @@ export default function UseCaseDetailPage() {
               </p>
             </div>
             <Link
-              to={/book?service=}
+              to={`/book?service=${config.serviceId}`}
               className="inline-flex items-center gap-2 rounded-2xl bg-cyan-500 px-5 py-3 text-sm font-semibold text-black transition hover:bg-cyan-400"
             >
               Book a demo <ArrowRight className="h-4 w-4" />
@@ -511,7 +511,7 @@ export default function UseCaseDetailPage() {
             {otherCases.map((item) => (
               <Link
                 key={item.slug}
-                to={/use-cases/}
+                to={`/use-cases/${item.slug}`}
                 className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/10 px-4 py-2 text-sm text-white/80 transition hover:border-cyan-300/60 hover:text-white"
               >
                 <span className="h-1.5 w-1.5 rounded-full bg-cyan-300" />


### PR DESCRIPTION
## Summary
- add a dedicated templates page and route that showcases template highlights and gallery
- correct string interpolation for use case detail metadata and links that were breaking builds

## Testing
- pnpm build

------
https://chatgpt.com/codex/tasks/task_b_68d5a3cb2d2c8331857de5edef1311f4